### PR TITLE
Fix touch input rotation / Disable single-touch mode

### DIFF
--- a/drivers/hid/hid-multitouch.c
+++ b/drivers/hid/hid-multitouch.c
@@ -169,7 +169,6 @@ struct mt_device {
 static void mt_post_parse_default_settings(struct mt_device *td,
 					   struct mt_application *app);
 static void mt_post_parse(struct mt_device *td, struct mt_application *app);
-static int cc_seen = 0;
 
 /* classes of device behavior */
 #define MT_CLS_DEFAULT				0x0001
@@ -796,11 +795,8 @@ static int mt_touch_input_mapping(struct hid_device *hdev, struct hid_input *hi,
 			app->scantime_logical_max = field->logical_maximum;
 			return 1;
 		case HID_DG_CONTACTCOUNT:
-			if(cc_seen != 1) {
-				app->have_contact_count = true;
-				app->raw_cc = &field->value[usage->usage_index];
-				cc_seen++;
-			}
+			app->have_contact_count = true;
+			app->raw_cc = &field->value[usage->usage_index];
 			return 1;
 		case HID_DG_AZIMUTH:
 			/*
@@ -1290,11 +1286,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
 	    field->application != HID_DG_TOUCHSCREEN &&
 	    field->application != HID_DG_PEN &&
 	    field->application != HID_DG_TOUCHPAD &&
-	    field->application != HID_GD_MOUSE &&
 	    field->application != HID_GD_KEYBOARD &&
 	    field->application != HID_GD_SYSTEM_CONTROL &&
 	    field->application != HID_CP_CONSUMER_CONTROL &&
-	    field->logical != HID_DG_TOUCHSCREEN &&
 	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
 	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
 	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
@@ -1345,14 +1339,6 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
 {
 	struct mt_device *td = hid_get_drvdata(hdev);
 	struct mt_report_data *rdata;
-
-	if (field->application == HID_DG_TOUCHSCREEN ||
-			field->application == HID_DG_TOUCHPAD) {
-		if (usage->type == EV_KEY || usage->type == EV_ABS)
-			set_bit(usage->type, hi->input->evbit);
-
-		return -1;
-	}
 
 	rdata = mt_find_report_data(td, field->report);
 	if (rdata && rdata->is_mt_collection) {
@@ -1565,13 +1551,12 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
 		/* already handled by hid core */
 		break;
 	case HID_DG_TOUCHSCREEN:
-		suffix = "Touchscreen";
+		/* we do not set suffix = "Touchscreen" */
 		hi->input->name = hdev->name;
 		break;
 	case HID_DG_STYLUS:
 		/* force BTN_STYLUS to allow tablet matching in udev */
 		__set_bit(BTN_STYLUS, hi->input->keybit);
-		__set_bit(INPUT_PROP_DIRECT, hi->input->propbit);
 		break;
 	case HID_VD_ASUS_CUSTOM_MEDIA_KEYS:
 		suffix = "Custom Media Keys";
@@ -1687,7 +1672,6 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
 	td->hdev = hdev;
 	td->mtclass = *mtclass;
 	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
-	cc_seen = 0;
 	hid_set_drvdata(hdev, td);
 
 	INIT_LIST_HEAD(&td->applications);

--- a/drivers/misc/ipts/ipts-dbgfs.c
+++ b/drivers/misc/ipts/ipts-dbgfs.c
@@ -22,75 +22,10 @@
 #include "ipts-state.h"
 #include "../mei/mei_dev.h"
 
-const char sensor_mode_fmt[] = "sensor mode : %01d\n";
-const char ipts_status_fmt[] = "sensor mode : %01d\nipts state : %01d\n";
+const char ipts_status_fmt[] = "ipts state : %01d\n";
 const char ipts_debug_fmt[] = ">> tdt : fw status : %s\n"
 							  ">> == DB s:%x, c:%x ==\n"
 							  ">> == WQ h:%u, t:%u ==\n";
-
-static ssize_t ipts_dbgfs_mode_read(struct file *fp, char __user *ubuf,
-						size_t cnt, loff_t *ppos)
-{
-	ipts_info_t *ipts = fp->private_data;
-	char mode[80];
-	int len = 0;
-
-	if (cnt < sizeof(sensor_mode_fmt) - 3)
-		return -EINVAL;
-
-	len = scnprintf(mode, 80, sensor_mode_fmt, ipts->sensor_mode);
-	if (len < 0)
-		return -EIO;
-
-	return simple_read_from_buffer(ubuf, cnt, ppos, mode, len);
-}
-
-static ssize_t ipts_dbgfs_mode_write(struct file *fp, const char __user *ubuf,
-						size_t cnt, loff_t *ppos)
-{
-	ipts_info_t *ipts = fp->private_data;
-	ipts_state_t state;
-	int sensor_mode, len;
-	char mode[3];
-
-	if (cnt == 0 || cnt > 3)
-		return -EINVAL;
-
-	state = ipts_get_state(ipts);
-	if (state != IPTS_STA_RAW_DATA_STARTED && state != IPTS_STA_HID_STARTED) {
-		return -EIO;
-	}
-
-	len = cnt;
-	if (copy_from_user(mode, ubuf, len))
-		return -EFAULT;
-
-	while(len > 0 && (isspace(mode[len-1]) || mode[len-1] == '\n'))
-		len--;
-	mode[len] = '\0';
-
-	if (sscanf(mode, "%d", &sensor_mode) != 1)
-		return -EINVAL;
-
-	if (sensor_mode != TOUCH_SENSOR_MODE_RAW_DATA &&
-					sensor_mode != TOUCH_SENSOR_MODE_HID) {
-		return -EINVAL;
-	}
-
-	if (sensor_mode == ipts->sensor_mode)
-		return 0;
-
-	ipts_switch_sensor_mode(ipts, sensor_mode);
-
-	return cnt;
-}
-
-static const struct file_operations ipts_mode_dbgfs_fops = {
-        .open = simple_open,
-        .read = ipts_dbgfs_mode_read,
-        .write = ipts_dbgfs_mode_write,
-        .llseek = generic_file_llseek,
-};
 
 static ssize_t ipts_dbgfs_status_read(struct file *fp, char __user *ubuf,
 						size_t cnt, loff_t *ppos)
@@ -102,8 +37,7 @@ static ssize_t ipts_dbgfs_status_read(struct file *fp, char __user *ubuf,
 	if (cnt < sizeof(ipts_status_fmt) - 3)
 		return -EINVAL;
 
-	len = scnprintf(status, 256, ipts_status_fmt, ipts->sensor_mode,
-						     ipts->state);
+	len = scnprintf(status, 256, ipts_status_fmt, ipts->state);
 	if (len < 0)
 		return -EIO;
 
@@ -298,13 +232,6 @@ int ipts_dbgfs_register(ipts_info_t* ipts, const char *name)
 	dir = debugfs_create_dir(name, NULL);
 	if (!dir)
 		return -ENOMEM;
-
-        f = debugfs_create_file("mode", S_IRUSR | S_IWUSR, dir,
-                                ipts, &ipts_mode_dbgfs_fops);
-        if (!f) {
-                ipts_err(ipts, "debugfs mode creation failed\n");
-                goto err;
-        }
 
         f = debugfs_create_file("status", S_IRUSR, dir,
                                 ipts, &ipts_status_dbgfs_fops);

--- a/drivers/misc/ipts/ipts-mei.c
+++ b/drivers/misc/ipts/ipts-mei.c
@@ -39,43 +39,6 @@ static struct mei_cl_device_id ipts_mei_cl_tbl[] = {
 	{}
 };
 
-static ssize_t sensor_mode_show(struct device *dev,
-				struct device_attribute *attr, char *buf)
-{
-	ipts_info_t *ipts;
-	ipts = dev_get_drvdata(dev);
-
-	return sprintf(buf, "%d\n", ipts->sensor_mode);
-}
-
-//TODO: Verify the function implementation
-static ssize_t sensor_mode_store(struct device *dev,
-				struct device_attribute *attr, const char *buf,
-				size_t count)
-{
-	int ret;
-	long val;
-	ipts_info_t *ipts;
-
-	ipts = dev_get_drvdata(dev);
-	ret = kstrtol(buf, 10, &val);
-	if (ret)
-	   return ret;
-
-	ipts_dbg(ipts, "try sensor mode = %ld\n", val);
-
-	switch (val) {
-		case TOUCH_SENSOR_MODE_HID:
-			break;
-		case TOUCH_SENSOR_MODE_RAW_DATA:
-			break;
-		default:
-			ipts_err(ipts, "sensor mode %ld is not supported\n", val);
-	}
-
-	return count;
-}
-
 static ssize_t device_info_show(struct device *dev,
 				struct device_attribute *attr, char *buf)
 {
@@ -89,12 +52,9 @@ static ssize_t device_info_show(struct device *dev,
 			ipts->device_info.vendor_id, ipts->device_info.device_id,
 			ipts->device_info.hw_rev, ipts->device_info.fw_rev);
 }
-
-static DEVICE_ATTR_RW(sensor_mode);
 static DEVICE_ATTR_RO(device_info);
 
 static struct attribute *ipts_attrs[] = {
-	&dev_attr_sensor_mode.attr,
 	&dev_attr_device_info.attr,
 	NULL
 };

--- a/drivers/misc/ipts/ipts-msg-handler.c
+++ b/drivers/misc/ipts/ipts-msg-handler.c
@@ -189,17 +189,6 @@ int ipts_restart(ipts_info_t *ipts)
 	return ret;
 }
 
-int ipts_switch_sensor_mode(ipts_info_t *ipts, int new_sensor_mode)
-{
-	int ret = 0;
-
-        ipts->new_sensor_mode = new_sensor_mode;
-	ipts->switch_sensor_mode = true;
-        ret = ipts_send_sensor_quiesce_io_cmd(ipts);
-
-	return ret;
-}
-
 #define rsp_failed(ipts, cmd, status) ipts_err(ipts, \
 				"0x%08x failed status = %d\n", cmd, status);
 

--- a/drivers/misc/ipts/ipts-msg-handler.h
+++ b/drivers/misc/ipts/ipts-msg-handler.h
@@ -20,7 +20,6 @@
 int ipts_handle_cmd(ipts_info_t *ipts, u32 cmd, void *data, int data_size);
 int ipts_start(ipts_info_t *ipts);
 void ipts_stop(ipts_info_t *ipts);
-int ipts_switch_sensor_mode(ipts_info_t *ipts, int new_sensor_mode);
 int ipts_handle_resp(ipts_info_t *ipts, touch_sensor_msg_m2h_t *m2h_msg,
                      u32 msg_len);
 int ipts_handle_processed_data(ipts_info_t *ipts);


### PR DESCRIPTION
Previous discussion:
* https://github.com/jakeday/linux-surface/issues/549

Currently, IPTS exposes two seperate touchscreen devices: One for single-touch and one for multi-touch. However, this confuses window managers such as GNOME's mutter, who cannot know which one is active at the moment. The result of that is that mutter will always rotate the single-touch device. The multi-touch one isn't rotated properly, even though multi-touch mode is whats probably being used in most cases. I am not sure if anyone actually uses single-touch mode to be honest.

Since the original IPTS implementation modified hid-multitouch to make single-touch mode work [1], reverting those changes disables single-touch, and fixes the touch input rotation in mutter. (Courtesy of @kitakar5525). This has the additional benefit of reducing the amout of changes to external code that IPTS makes. The alternative is to expose it as a stylus, which doesn't really work that well, and still requires patches to hid-multitouch.

Since the APIs to switch between multi-touch and single-touch mode are pretty much useless now, the second commit removes them. Internally though, IPTS still has code to handle mode switching since that is part of the initialisation process as it seems.

* [1] https://github.com/ipts-linux-org/ipts-linux-new/commit/7cc1f5419bb16ad6584d3ddac9e8b62ea2a8b5f7