### PR TITLE
Add secureboot pre-signing to the kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,9 @@ signing_key.priv
 signing_key.x509
 x509.genkey
 
+# Secureboot certificate
+/keys/
+
 # Kconfig presets
 /all.config
 /alldef.config

--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -284,6 +284,7 @@ endif
 	$(Q)$(MAKE) $(build)=$(boot) $(KBUILD_IMAGE)
 	$(Q)mkdir -p $(objtree)/arch/$(UTS_MACHINE)/boot
 	$(Q)ln -fsn ../../x86/boot/bzImage $(objtree)/arch/$(UTS_MACHINE)/boot/$@
+	$(Q)$(srctree)/scripts/sign_kernel.sh $(objtree)/arch/$(UTS_MACHINE)/boot/$@
 
 $(BOOT_TARGETS): vmlinux
 	$(Q)$(MAKE) $(build)=$(boot) $@

--- a/scripts/sign_kernel.sh
+++ b/scripts/sign_kernel.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+
+# The path to the compiled kernel image is passed as the first argument
+BUILDDIR=$(dirname $(dirname $0))
+VMLINUX=$1
+
+# Keys are stored in a toplevel directory called keys
+# The following files need to be there:
+#     * MOK.priv  (private key)
+#     * MOK.pem   (public key)
+#
+# If the files don't exist, this script will do nothing.
+if [[ ! -f "$BUILDDIR/keys/MOK.key" ]]; then
+    exit 0
+fi
+if [[ ! -f "$BUILDDIR/keys/MOK.crt" ]]; then
+    exit 0
+fi
+
+# Both required certificates were found. Check if sbsign is installed.
+echo "Keys for automatic secureboot signing found."
+if [[ ! -x "$(command -v sbsign)" ]]; then
+    echo "ERROR: sbsign not found!"
+    exit -2
+fi
+
+# Sign the kernel
+sbsign --key $BUILDDIR/keys/MOK.key --cert $BUILDDIR/keys/MOK.crt \
+    --output $VMLINUX $VMLINUX


### PR DESCRIPTION
This adds the ability for you and other packagers to pre-sign the kernels for secureboot. 

The kernel build system will look for two files:
* `keys/MOK.key` (private key)
* `keys/MOK.crt` (public key in PEM format)

and sign the produced vmlinux / bzImage file with it. If no keys are found, it will be silently ignored and the kernel will be unsigned.

Adding it to the build system avoids having to wrap everything. Right now you need to first to `make all`, then sign the image, and then do something like `make bindeb-pkg`. With this, you can just add your keys to the kernel source, and run `make deb-pkg`.

Users then only need to be able to download the public key (in DER format), and enroll it into `shim` to be able to boot the kernel - instead of generating the keys and signing the kernel all on their own. 

We could also edit the Arch / Debian packaging templates to install the key automatically (like [this](https://github.com/StollD/fedora-linux-surface/blob/master/pkg/linux-surface-secureboot/linux-surface-secureboot.spec#L30-L33)), or package them seperately if we ever get to setting up a package repository for this.