### PR TITLE
Move no_feedback DMI check to the companion driver

### DIFF
--- a/drivers/misc/ipts/companion.c
+++ b/drivers/misc/ipts/companion.c
@@ -210,19 +210,19 @@ config_fallback:
 
 }
 
-bool ipts_needs_no_feedback(void)
+unsigned int ipts_get_quirks(void)
 {
-	bool ret;
+	unsigned int ret;
 
 	// Make sure that access to the companion is synchronized
 	mutex_lock(&ipts_companion_lock);
 
 	// If the companion is ignored, or doesn't exist, assume that
-	// the device doesn't need no_feedback enabled
+	// the device doesn't have any quirks
 	if (ipts_modparams.ignore_companion || ipts_companion == NULL)
-		ret = false;
+		ret = IPTS_QUIRK_NONE;
 	else
-		ret = ipts_companion->needs_no_feedback(ipts_companion);
+		ret = ipts_companion->get_quirks(ipts_companion);
 
 	mutex_unlock(&ipts_companion_lock);
 

--- a/drivers/misc/ipts/companion.c
+++ b/drivers/misc/ipts/companion.c
@@ -209,3 +209,22 @@ config_fallback:
 	return ret;
 
 }
+
+bool ipts_needs_no_feedback(void)
+{
+	bool ret;
+
+	// Make sure that access to the companion is synchronized
+	mutex_lock(&ipts_companion_lock);
+
+	// If the companion is ignored, or doesn't exist, assume that
+	// the device doesn't need no_feedback enabled
+	if (ipts_modparams.ignore_companion || ipts_companion == NULL)
+		ret = false;
+	else
+		ret = ipts_companion->needs_no_feedback(ipts_companion);
+
+	mutex_unlock(&ipts_companion_lock);
+
+	return ret;
+}

--- a/drivers/misc/ipts/companion.h
+++ b/drivers/misc/ipts/companion.h
@@ -15,6 +15,7 @@
 #include "ipts.h"
 
 bool ipts_companion_available(void);
+bool ipts_needs_no_feedback(void);
 
 int ipts_request_firmware(const struct firmware **fw, const char *name,
 		struct device *device);

--- a/drivers/misc/ipts/companion.h
+++ b/drivers/misc/ipts/companion.h
@@ -15,7 +15,7 @@
 #include "ipts.h"
 
 bool ipts_companion_available(void);
-bool ipts_needs_no_feedback(void);
+unsigned int ipts_get_quirks(void);
 
 int ipts_request_firmware(const struct firmware **fw, const char *name,
 		struct device *device);

--- a/drivers/misc/ipts/companion/ipts-surface.c
+++ b/drivers/misc/ipts/companion/ipts-surface.c
@@ -28,49 +28,49 @@
 
 struct ipts_surface_data {
 	const char *hid;
-	bool no_feedback;
+	unsigned int quirks;
 };
 
 // Surface Book 1 / Surface Studio
 static const struct ipts_surface_data ipts_surface_mshw0076 = {
 	.hid = "MSHW0076",
-	.no_feedback = true,
+	.quirks = IPTS_QUIRK_NO_FEEDBACK,
 };
 
 // Surface Pro 4
 static const struct ipts_surface_data ipts_surface_mshw0078 = {
 	.hid = "MSHW0078",
-	.no_feedback = true,
+	.quirks = IPTS_QUIRK_NO_FEEDBACK,
 };
 
 // Surface Laptop 1 / 2
 static const struct ipts_surface_data ipts_surface_mshw0079 = {
 	.hid = "MSHW0079",
-	.no_feedback = false,
+	.quirks = IPTS_QUIRK_NONE,
 };
 
 // Surface Pro 5 / 6
 static const struct ipts_surface_data ipts_surface_mshw0101 = {
 	.hid = "MSHW0101",
-	.no_feedback = false,
+	.quirks = IPTS_QUIRK_NONE,
 };
 
 // Surface Book 2 15"
 static const struct ipts_surface_data ipts_surface_mshw0102 = {
 	.hid = "MSHW0102",
-	.no_feedback = false,
+	.quirks = IPTS_QUIRK_NONE,
 };
 
 // Unknown, but firmware exists
 static const struct ipts_surface_data ipts_surface_mshw0103 = {
 	.hid = "MSHW0103",
-	.no_feedback = false,
+	.quirks = IPTS_QUIRK_NONE,
 };
 
 // Surface Book 2 13"
 static const struct ipts_surface_data ipts_surface_mshw0137 = {
 	.hid = "MSHW0137",
-	.no_feedback = false,
+	.quirks = IPTS_QUIRK_NONE,
 };
 
 /*
@@ -83,7 +83,7 @@ int ipts_surface_request_firmware(struct ipts_companion *companion,
 		const struct firmware **fw, const char *name,
 		struct device *device);
 
-bool ipts_surface_needs_no_feedback(struct ipts_companion *companion);
+unsigned int ipts_surface_get_quirks(struct ipts_companion *companion);
 
 static struct ipts_bin_fw_info ipts_surface_vendor_kernel = {
 	.fw_name = "vendor_kernel.bin",
@@ -119,7 +119,7 @@ static struct ipts_bin_fw_info *ipts_surface_fw_config[] = {
 static struct ipts_companion ipts_surface_companion = {
 	.firmware_request = &ipts_surface_request_firmware,
 	.firmware_config = ipts_surface_fw_config,
-	.needs_no_feedback = &ipts_surface_needs_no_feedback,
+	.get_quirks = &ipts_surface_get_quirks,
 	.name = "ipts_surface",
 };
 
@@ -140,18 +140,18 @@ int ipts_surface_request_firmware(struct ipts_companion *companion,
 	return request_firmware(fw, fw_path, device);
 }
 
-bool ipts_surface_needs_no_feedback(struct ipts_companion *companion)
+unsigned int ipts_surface_get_quirks(struct ipts_companion *companion)
 {
 	struct ipts_surface_data *data;
 
-	// In case something went wrong, assume that the device doesn't
-	// need the no_feedback option set
+	// In case something went wrong, assume that the
+	// device doesn't have any quirks
 	if (companion == NULL || companion->data == NULL)
-		return false;
+		return IPTS_QUIRK_NONE;
 
 	data = (struct ipts_surface_data *)companion->data;
 
-	return data->no_feedback;
+	return data->quirks;
 }
 
 static int ipts_surface_probe(struct platform_device *pdev)

--- a/drivers/misc/ipts/hid.c
+++ b/drivers/misc/ipts/hid.c
@@ -9,6 +9,7 @@
 #include <linux/dmi.h>
 #include <linux/firmware.h>
 #include <linux/hid.h>
+#include <linux/ipts.h>
 #include <linux/module.h>
 #include <linux/vmalloc.h>
 
@@ -444,8 +445,12 @@ static int handle_outputs(struct ipts_info *ipts, int parallel_idx)
 	 */
 	if (fb_buf) {
 		// A negative value means "decide by dmi table"
-		if (ipts_modparams.no_feedback < 0)
-			ipts_modparams.no_feedback = ipts_needs_no_feedback();
+		if (ipts_modparams.no_feedback < 0) {
+			if (ipts_get_quirks() & IPTS_QUIRK_NO_FEEDBACK)
+				ipts_modparams.no_feedback = true;
+			else
+				ipts_modparams.no_feedback = false;
+		}
 
 		if (ipts_modparams.no_feedback)
 			return 0;

--- a/include/linux/ipts-companion.h
+++ b/include/linux/ipts-companion.h
@@ -14,6 +14,7 @@
 #include <linux/ipts-binary.h>
 
 struct ipts_companion {
+	bool (*needs_no_feedback)(struct ipts_companion *companion);
 	int (*firmware_request)(struct ipts_companion *companion,
 		const struct firmware **fw,
 		const char *name, struct device *device);

--- a/include/linux/ipts-companion.h
+++ b/include/linux/ipts-companion.h
@@ -14,7 +14,7 @@
 #include <linux/ipts-binary.h>
 
 struct ipts_companion {
-	bool (*needs_no_feedback)(struct ipts_companion *companion);
+	unsigned int (*get_quirks)(struct ipts_companion *companion);
 	int (*firmware_request)(struct ipts_companion *companion,
 		const struct firmware **fw,
 		const char *name, struct device *device);

--- a/include/linux/ipts.h
+++ b/include/linux/ipts.h
@@ -9,7 +9,12 @@
 #ifndef IPTS_H
 #define IPTS_H
 
+#include <linux/bits.h>
+
 #define MAX_IOCL_FILE_NAME_LEN 80
 #define MAX_IOCL_FILE_PATH_LEN 256
+
+#define IPTS_QUIRK_NONE        0
+#define IPTS_QUIRK_NO_FEEDBACK BIT(0)
 
 #endif // IPTS_H


### PR DESCRIPTION
Having a DMI match for some surface devices doesn't really match with the concept of having a device-specific companion driver, so this moves the matching code to the companion.

ipts-surface is now setup in a way that allows us to add device-specificn data pretty easily. All you need is the interface to IPTS, which can just be copied from no_feedback.