### PR TITLE
surface3-spi: workaround: disable DMA mode to avoid crash by default

### DIFF
--- a/drivers/input/touchscreen/surface3_spi.c
+++ b/drivers/input/touchscreen/surface3_spi.c
@@ -25,6 +25,12 @@
 #define SURFACE3_REPORT_TOUCH	0xd2
 #define SURFACE3_REPORT_PEN	0x16
 
+bool use_dma = false;
+module_param(use_dma, bool, 0644);
+MODULE_PARM_DESC(use_dma,
+				"Disable DMA mode if you encounter touch input crash. "
+				"(default: false, disabled to avoid crash)");
+
 struct surface3_ts_data {
 	struct spi_device *spi;
 	struct gpio_desc *gpiod_rst[2];
@@ -326,6 +332,13 @@ static int surface3_spi_create_pen_input(struct surface3_ts_data *data)
 	return 0;
 }
 
+static bool surface3_spi_can_dma(struct spi_controller *ctlr,
+				struct spi_device *spi,
+				struct spi_transfer *tfr)
+{
+	return use_dma;
+}
+
 static int surface3_spi_probe(struct spi_device *spi)
 {
 	struct surface3_ts_data *data;
@@ -367,6 +380,19 @@ static int surface3_spi_probe(struct spi_device *spi)
 					  "Surface3-irq", data);
 	if (error)
 		return error;
+
+	/*
+	 * Set up DMA
+	 *
+	 * TODO: Currently, touch input with DMA seems to be broken.
+	 * On 4.19 LTS, touch input will crash after suspend.
+	 * On recent stable kernel (at least after 5.1), touch input will crash after
+	 * the first touch. No problem with PIO on those kernels.
+	 * Maybe we need to configure DMA here.
+	 *
+	 * Link to issue: https://github.com/jakeday/linux-surface/issues/596
+	 */
+	spi->controller->can_dma = surface3_spi_can_dma;
 
 	return 0;
 }


### PR DESCRIPTION
Hello, on Surface 3, we're facing touch input crash with some kernel config setup, especially with your build and Arch Linux stock kernel.

It turned out that DMA mode seems to be broken with surface3-spi touchscreen driver. So, this commit will disable DMA mode by default and use PIO mode instead for the driver.
Any other changes beyond Surface 3 touchscreen are not intended.

If you find something is weird, let me know. Also, this is just a workaround, I should actually fix   this driver with DMA mode if I can. So, If you know how to set up DMA mode, also please let me know.

Link to issue: jakeday/linux-surface#596

Tested on Arch Linux 5.4.1 with Surface 3, which will use DMA by default.
This commit made the driver use PIO by default and no touch input crash.
Also tested on chromeos-4.19 4.19.90 with Surface 3, which will use PIO by default
even without this commit. After this commit, it still uses PIO and confirmed
no functional changes regarding touch input.