### PR TITLE
media: i2c: Expand gain values for ov5693

### DIFF
--- a/drivers/media/i2c/ov5693.c
+++ b/drivers/media/i2c/ov5693.c
@@ -48,10 +48,10 @@
 
 /* Analogue Gain */
 #define OV5693_GAIN_CTRL_REG			CCI_REG16(0x350a)
-#define OV5693_GAIN_CTRL_MASK			GENMASK(10, 4)
+#define OV5693_GAIN_CTRL_MASK			GENMASK(10, 0)
 #define OV5693_GAIN_MIN				1
-#define OV5693_GAIN_MAX				127
-#define OV5693_GAIN_DEF				8
+#define OV5693_GAIN_MAX				2047
+#define OV5693_GAIN_DEF				16
 #define OV5693_GAIN_STEP			1
 
 /* Digital Gain */
@@ -444,7 +444,7 @@ static int ov5693_analog_gain_configure(struct ov5693_device *ov5693, u32 gain)
 {
 	int ret = 0;
 
-	gain = (gain << 4) & OV5693_GAIN_CTRL_MASK;
+	gain &= OV5693_GAIN_CTRL_MASK;
 
 	cci_write(ov5693->regmap, OV5693_GAIN_CTRL_REG, gain, &ret);
 


### PR DESCRIPTION
The ov5693 driver currently allows values for the
V4L2_CID_ANALOGUE_GAIN control in the range 1-127. The input values are left-shifted 4 bits before being applied to the hardware. The 4 least significant bits are fractional bits, which means that in practice gain can only be applied in steps of 1.0.

Update the allowed range to take any value that fits into the 11-bit register and stop masking off the fractional bits.

Note that libcamera treated the ov5693 as though this change were already applied, which meant that by default 16x gain was being applied. This change therefore reduces the noise of the user-facing camera quite a bit; see the attached images
<img width="2560" height="1920" alt="post-fix" src="https://github.com/user-attachments/assets/93fbc6d8-ba0b-4218-8b1e-f599723550ab" />
<img width="2560" height="1920" alt="pre-fix" src="https://github.com/user-attachments/assets/08688655-aab5-42b0-bb7e-428fe1d6fb37" />
