### PR TITLE
Surface Pro 9: fix rear camera rotation

### DIFF
--- a/drivers/media/pci/intel/ipu-bridge.c
+++ b/drivers/media/pci/intel/ipu-bridge.c
@@ -291,9 +291,11 @@ static u32 ipu_bridge_parse_rotation(struct acpi_device *adev,
 {
 	const struct dmi_system_id *dmi_id;
 
-	dmi_id = dmi_first_match(upside_down_sensor_dmi_ids);
-	if (dmi_id && acpi_dev_hid_match(adev, dmi_id->driver_data))
-		return 180;
+	/* A machine may have one entry per sensor, so check all matches. */
+	for (dmi_id = dmi_first_match(upside_down_sensor_dmi_ids); dmi_id;
+	     dmi_id = dmi_first_match(dmi_id + 1))
+		if (acpi_dev_hid_match(adev, dmi_id->driver_data))
+			return 180;
 
 	switch (ssdb->degree) {
 	case IPU_SENSOR_ROTATION_NORMAL:

--- a/drivers/media/pci/intel/ipu-bridge.c
+++ b/drivers/media/pci/intel/ipu-bridge.c
@@ -136,6 +136,13 @@ static const struct dmi_system_id upside_down_sensor_dmi_ids[] = {
 		},
 		.driver_data = "OVTI5693",
 	},
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Pro 9"),
+		},
+		.driver_data = "OVTID858",
+	},
 	{} /* Terminating entry */
 };
 


### PR DESCRIPTION
The rear OV13858 camera (OVTID858) of the Surface Pro 9 comes out rotated 180°: the firmware SSDB reports `degree=0`, and the existing DMI quirk in `ipu-bridge` only covers the front OVTI5693 camera (added in #160).

Fixing it takes two commits:

1. **`media: ipu-bridge: check all DMI entries when overriding sensor rotation`** — `ipu_bridge_parse_rotation()` uses `dmi_first_match()`, which always stops at the first entry matching the running machine, so a second entry for the same machine (needed for a second sensor) is unreachable. Walk the whole table and match each entry for the running machine against the sensor's ACPI HID instead. This is a general fix, not SP9-specific; I intend to send it to linux-media mainline as well.
2. **`media: ipu-bridge: fix rear camera rotation on Surface Pro 9`** — add the `Surface Pro 9` → `OVTID858` quirk entry, next to the existing front-camera one.

**Tested on a Surface Pro 9** (kernel `6.19.8-3.surface.fc43`, module rebuilt from `v6.19-surface`):

- `libcamera` now reports `Rotation = 180` for the rear camera (was 0) and the image renders upright in GNOME Snapshot.
- No regression on the front camera: still `Rotation = 180`, upright image, cold first-open works.
- Both cameras keep delivering frames (`cam --capture`), no new `ipu-bridge`/`ov5693`/`ov13858` errors in dmesg.
