### PR TITLE
platform/surface: aggregator_registry: Add Surface Pro 12 (Intel)

### DIFF
--- a/drivers/platform/surface/surface_aggregator_registry.c
+++ b/drivers/platform/surface/surface_aggregator_registry.c
@@ -433,6 +433,9 @@ static const struct acpi_device_id ssam_platform_hub_acpi_match[] = {
 	/* Surface Pro 11 */
 	{ "MSHW0583", (unsigned long)ssam_node_group_sp9 },
 
+	/* Surface Pro 12 (Intel) */
+	{ "MSHW0743", (unsigned long)ssam_node_group_sp9 },
+
 	/* Surface Book 2 */
 	{ "MSHW0107", (unsigned long)ssam_node_group_gen5 },
 


### PR DESCRIPTION
### Summary

Add the Surface Pro 12 for Business (Intel) platform-hub ACPI ID MSHW0743 to the Surface Aggregator registry and reuse ssam_node_group_sp9.

This follows the existing model used for the Surface Pro 10 (MSHW0510) and Surface Pro 11 Intel (MSHW0583), which also reuse the Surface Pro 9 SAM client-device group.

On the tested Surface Pro for Business 13in 12th Ed Intel, this enables the SSAM platform devices and the associated basic Surface platform functionality.

### Upstream intent

I would like to upstream this particular change as soon as practical after linux-surface review.

The change is small scoped to the new MSHW0743 ACPI ID, and is directly analogous to the already-upstream Surface Pro 10 and Surface Pro 11 Intel registry additions.

I am opening it here first so the linux-surface maintainers can confirm the SP12 registry mapping and so it is tracked together with the rest of the Surface Pro 12 enablement work.

### Testing

Tested on Surface Pro for Business 13in 12th Ed Intel.

The MSHW0743 registry entry has been used in the tested SP12 kernel and enables the expected Surface Aggregator client devices, including the platform functionality used by battery, thermal/fan and UCSI support.

### Surface Pro 12 enablement

This is one part of the broader Surface Pro 12 enablement work, tracked in  linux-surface/linux-surface#2144

#### Related Surface Pro 12 work

- MSHW0040 button deferred probing: linux-surface/kernel#172
- SSAM POS zero-padded source-list parsing: linux-surface/kernel#173