### PR TITLE
platform/surface: aggregator_tabletsw: accept zero-padded source-list responses

### DIFF
--- a/drivers/platform/surface/surface_aggregator_tabletsw.c
+++ b/drivers/platform/surface/surface_aggregator_tabletsw.c
@@ -9,6 +9,7 @@
 #include <linux/input.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/string.h>
 #include <linux/types.h>
 #include <linux/workqueue.h>
 
@@ -328,6 +329,7 @@ MODULE_PARM_DESC(tablet_mode_in_slate_state, "Enable tablet mode in slate device
 
 #define SSAM_EVENT_POS_CID_POSTURE_CHANGED	0x03
 #define SSAM_POS_MAX_SOURCES			4
+#define SSAM_POS_SOURCE_LIST_PADDING_SIZE	sizeof(__le32)
 
 enum ssam_pos_source_id {
 	SSAM_POS_SOURCE_COVER = 0x00,
@@ -353,6 +355,7 @@ enum ssam_pos_state_sls {
 struct ssam_sources_list {
 	__le32 count;
 	__le32 id[SSAM_POS_MAX_SOURCES];
+	u8 padding[SSAM_POS_SOURCE_LIST_PADDING_SIZE];
 } __packed;
 
 static const char *ssam_pos_state_name_cover(struct ssam_tablet_sw *sw, u32 state)
@@ -477,6 +480,8 @@ static int ssam_pos_get_sources_list(struct ssam_tablet_sw *sw, struct ssam_sour
 {
 	struct ssam_request rqst;
 	struct ssam_response rsp;
+	u32 count;
+	size_t expected;
 	int status;
 
 	rqst.target_category = SSAM_SSH_TC_POS;
@@ -501,8 +506,15 @@ static int ssam_pos_get_sources_list(struct ssam_tablet_sw *sw, struct ssam_sour
 		return -EPROTO;
 	}
 
-	/* Make sure 'sources->count' matches with the response length. */
-	if (get_unaligned_le32(&sources->count) * sizeof(__le32) + sizeof(__le32) != rsp.length) {
+	count = get_unaligned_le32(&sources->count);
+	if (count > ARRAY_SIZE(sources->id)) {
+		dev_err(&sw->sdev->dev, "too many posture sources: %u\n", count);
+		return -EPROTO;
+	}
+
+	expected = sizeof(sources->count) + count * sizeof(sources->id[0]);
+	if (rsp.length < expected ||
+	    memchr_inv((u8 *)sources + expected, 0, rsp.length - expected)) {
 		dev_err(&sw->sdev->dev, "mismatch between number of sources and response size\n");
 		return -EPROTO;
 	}


### PR DESCRIPTION
### Summary

Allow the Surface Aggregator POS source-list parser to accept bounded, zero-filled trailing response data.

The Surface Pro 12 for Business Intel provides a reproducer (In combination with Flex Keyboard). Its POS source-list command returns a 24-byte response:

```text
count = 1
id[0] = 0x00
remaining 16 bytes = 0x00
````

This describes one Type-Cover posture source. The additional bytes are zero-filled trailing data, not additional posture sources.

The current driver requires the response length to exactly equal:

```text
sizeof(count) + count * sizeof(source_id)
```

and its source-list response buffer is only 20 bytes.

As a result, the POS/tablet-mode client fails to probe on the SP12.

### Proposed handling

This PR:

1. increases the source-list response capacity from 20 to 24 bytes;
2. validates that the reported source count fits in the existing
   four-entry source array;
3. calculates the minimum response length represented by that count; and
4. accepts any remaining bytes only when every trailing byte is zero.

The resulting validation is effectively:

```c
count = get_unaligned_le32(&sources->count);

if (count > ARRAY_SIZE(sources->id))
        return -EPROTO;

expected = sizeof(sources->count) +
           count * sizeof(sources->id[0]);

if (rsp.length < expected ||
    memchr_inv((u8 *)sources + expected, 0, rsp.length - expected))
        return -EPROTO;
```

So this does not generally relax response validation.

The following continue to be rejected:

* a response shorter than required by `count`;
* more sources than fit in the fixed source array;
* any non-zero trailing response data.

Existing exact-length responses continue to be accepted unchanged.

### Why add four bytes to the response structure?

The existing structure contains:

```text
count:       4 bytes
id[4]:      16 bytes
--------------------
total:      20 bytes
```

and is also used directly as the response buffer:

```c
rsp.capacity = sizeof(*sources);
```

The SP12 returns 24 bytes, so validating trailing data alone is not sufficient: the response buffer must first be large enough to receive the complete response.

An additional four-byte padding field raises the maximum accepted response size to 24 bytes.

For the observed SP12 response with `count = 1`, the semantic payload is 8 bytes and all 16 bytes after it are verified to be zero.

### Surface Pro 12 reproducer

Tested on:

```text
Microsoft Surface Pro for Business 13in 12th Ed Intel
MSHW0743 / Panther Lake
```

Before this change the SSAM POS/tablet-mode client failed during probe.

The SP12 firmware response was observed as:

```text
response length: 24 bytes
count:           1
source id[0]:    0x00
trailing bytes:  16 x 0x00
```

With this patch:

* `surface_aggregator_tabletsw` binds normally at boot;
* `Microsoft Surface POS Tablet Mode Switch` is created;
* the device exposes `EV_SW` / `SW_TABLET_MODE`.

Physical testing produced:

```text
Flex Keyboard attached:    SW_TABLET_MODE = 0
Flex Keyboard detached:    SW_TABLET_MODE = 1
Flex Keyboard reattached:  SW_TABLET_MODE = 0
```

The full SP12 investigation is documented here:

[https://github.com/linux-surface/linux-surface/issues/2144#issuecomment-5264372177](https://github.com/linux-surface/linux-surface/issues/2144#issuecomment-5264372177)


### Testing / review scope

The exact patch in this PR has already been runtime-tested on the SP12.

It has also been compile-tested against `v6.19-surface-devel` using the current linux-surface Arch kernel configuration.

Because this changes the generic SSAM POS source-list parser rather than adding an SP12-specific device quirk, testing on other devices using the POS tablet-mode implementation would be useful.

In particular I would like to confirm that existing exact-length responses continue to behave unchanged.

### Surface Pro 12 enablement

This is one independently reviewable part of the broader Surface Pro 12
Intel enablement work:

linux-surface/linux-surface#2144

Related draft PRs:

* SSAM / MSHW0743 registry: linux-surface/kernel#171
* MSHW0040 button deferred probing: linux-surface/kernel#172
