### PR TITLE
media: intel/ipu-bridge: fix OVTID858 link frequencies

### DIFF
--- a/drivers/media/pci/intel/ipu-bridge.c
+++ b/drivers/media/pci/intel/ipu-bridge.c
@@ -63,8 +63,8 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
 	IPU_SENSOR_CONFIG("INT33F0", 1, 384000000),
 	/* Omnivision OV5693 - Surface Pro 9 */
 	IPU_SENSOR_CONFIG("OVTI5693", 1, 419200000),
-	/* Omnivision OV13858 - Surface Pro 9 */
-	IPU_SENSOR_CONFIG("OVTID858", 4, 540000000),
+	/* Omnivision OV13858 */
+	IPU_SENSOR_CONFIG("OVTID858", 2, 540000000, 270000000),
 	/* Omnivision OV2740 */
 	IPU_SENSOR_CONFIG("INT3474", 1, 180000000),
 	/* Omnivision OV5670 */


### PR DESCRIPTION
### Summary

Fix the `OVTID858` / OV13858 entry in `ipu-bridge` to publish the two link frequencies supported by the OV13858 driver.

The existing entry is:

```c
/* Omnivision OV13858 - Surface Pro 9 */
IPU_SENSOR_CONFIG("OVTID858", 4, 540000000),
````

The second argument to `IPU_SENSOR_CONFIG()` is `nr_link_freqs`, not the CSI lane count. The bridge obtains the actual lane count separately from firmware SSDB.

The OV13858 driver itself exposes exactly two link frequencies, 540 MHz and 270 MHz, in its [`LINK_FREQ` control menu](https://github.com/linux-surface/kernel/blob/7d3b3154572eaedfdb72f5a00c3590355ba0ec00/drivers/media/i2c/ov13858.c#L948-L971), and [uses those two entries across its supported modes](https://github.com/linux-surface/kernel/blob/7d3b3154572eaedfdb72f5a00c3590355ba0ec00/drivers/media/i2c/ov13858.c#L992-L1038) https://github.com/linux-surface/kernel/blob/7d3b3154572eaedfdb72f5a00c3590355ba0ec00/drivers/media/i2c/ov13858.c#L992-L1038

Reflect that in the bridge configuration:

```c
/* Omnivision OV13858 */
IPU_SENSOR_CONFIG("OVTID858", 2, 540000000, 270000000),
```

The entry was originally annotated for Surface Pro 9, but OVTID858 is also used by later Surface Pro generations, so make the comment device-independent.

### Testing

The 540/270 MHz configuration was independently used successfully while enabling the OV13858 rear camera on Surface Pro 12 Intel.

The existing linux-surface OV13858 support was also separately confirmed to probe and stream the same camera on Surface Pro 12 Intel.

Related Surface Pro 12 enablement tracking: linux-surface/linux-surface#2144.

### Related Surface Pro 12 camera work

- Rear OV13858 mounting rotation: linux-surface/kernel#175
- Front IMX681 / SONY0681 support RFC: linux-surface/kernel#176