### PR TITLE
media: intel/ipu-bridge: fix rear camera rotation on Surface Pro 12 (Intel)

### DIFF
--- a/drivers/media/pci/intel/ipu-bridge.c
+++ b/drivers/media/pci/intel/ipu-bridge.c
@@ -136,6 +136,15 @@ static const struct dmi_system_id upside_down_sensor_dmi_ids[] = {
 		},
 		.driver_data = "OVTI5693",
 	},
+	{
+		.matches = {
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME,
+					"Surface Pro for Business 13in 12th Ed Intel"),
+		},
+		/* OVTID858 is the rear camera on this model. */
+		.driver_data = "OVTID858",
+	},
 	{} /* Terminating entry */
 };
 


### PR DESCRIPTION
### Summary

Fix the mounting rotation reported for the `OVTID858` / OV13858 rear camera on Surface Pro 12 Intel.

On the tested Surface Pro for Business 13in 12th Ed Intel, the rear sensor is physically mounted with a 180° rotation, but its firmware metadata reports the normal orientation. `ipu-bridge` therefore exposes a rotation of 0° and userspace displays the camera upside down.

Add the tested Surface Pro 12 Intel DMI identity and `OVTID858` to the existing upside-down sensor quirk table. This corrects the mounting metadata only; it does not rotate image data or alter OV13858 register programming.

### Testing

Tested on Surface Pro 12 for BusinessIntel.

- Rear `OVTID858` / OV13858 rotation: 180°
- Front camera rotation: 0°
- Rear camera displayed upright in userspace

The rear camera probes and streams successfully with the existing linux-surface OV13858 support.

Related work: linux-surface/kernel#170 adds an equivalent `OVTID858` rotation quirk for Surface Pro 9 and fixes handling of multiple sensor-rotation quirks for the same machine. This SP12 entry is independent of that parser change on the current Surface Pro 12 configuration.

Related Surface Pro 12 enablement tracking: linux-surface/linux-surface#2144.

#### Related Surface Pro 12 camera work

- OVTID858 / OV13858 link-frequency metadata: linux-surface/kernel#174
- Front IMX681 / SONY0681 support RFC: linux-surface/kernel#176